### PR TITLE
Fixes to run on OpenCV 3.2 / ROS Melodic

### DIFF
--- a/aruco_detection/include/aruco_detection/ArucoBoard.hpp
+++ b/aruco_detection/include/aruco_detection/ArucoBoard.hpp
@@ -24,6 +24,10 @@
 	typedef cv::aruco::Board BoardType;
 #endif
 
+#if CV_VERSION_MAJOR >= 3 and CV_VERSION_MINOR >= 3
+#define CV_ARUCO_OPENCV_3_3
+#endif
+
 namespace aruco {
 
 extern const std::map<std::string, cv::aruco::PREDEFINED_DICTIONARY_NAME> aruco_dict_lookup;
@@ -38,6 +42,10 @@ struct ArucoBoard {
 #else
 	typedef cv::aruco::Dictionary DictType;
 	typedef cv::aruco::Board BoardType;
+#endif
+
+#if CV_VERSION_MAJOR >= 3 and CV_VERSION_MINOR >= 3
+#define CV_ARUCO_OPENCV_3_3
 #endif
 
 	std::string name;


### PR DESCRIPTION
`cv::aruco::getBoardObjectAndImagePoints` was not added until OpenCV 3.3. I added preprocessor guards to use the original commented out method and changed the header check to 3.3 instead of 3.2.